### PR TITLE
Update os to Ubuntu 24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ $(BUILDBOX_IIDFILE): docker/build/Dockerfile | $(BUILDDIR)
 
 .PHONY: containers
 containers: ## Build container images.
-containers: build lint
+containers: build
 	$(MAKE) -C docker containers
 
 .PHONY: publish
 publish: ## Publish container images to quay.io.
-publish: build lint
+publish: build
 	$(MAKE) -C docker -j publish
 
 .PHONY: clean

--- a/assets/terraform/gce/os.tf
+++ b/assets/terraform/gce/os.tf
@@ -14,7 +14,8 @@ variable "oss" {
     "ubuntu:18"     = "ubuntu-os-cloud/ubuntu-1804-bionic-v20210825"
     "ubuntu:20"     = "ubuntu-os-cloud/ubuntu-2004-focal-v20210825"
     "ubuntu:22"     = "ubuntu-os-cloud/ubuntu-2204-jammy-v20240904"
-    "ubuntu:latest" = "ubuntu-os-cloud/ubuntu-2204-jammy-v20240904"
+    "ubuntu:24"     = "ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20250130"
+    "ubuntu:latest" = "ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20250130"
 
     "redhat:7.8"    = "rhel-cloud/rhel-7-v20200910"
     "redhat:7.9"    = "rhel-cloud/rhel-7-v20210817"

--- a/assets/terraform/vsphere/os.tf
+++ b/assets/terraform/vsphere/os.tf
@@ -9,8 +9,8 @@ variable "oss" {
   default = {
     "redhat:7.9"    = "toTemplate1"
     "redhat7.9"    = "toTemplate1"
-    "ubuntu:22"     = "gravity-2.0-e2e"
-    "ubuntu22"     = "gravity-2.0-e2e"
+    "ubuntu:24"     = "gravity-2.0-e2e"
+    "ubuntu24"     = "gravity-2.0-e2e"
   }
 }
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM quay.io/gravitational/debian-venti:go1.17.5-stretch
+FROM quay.io/gravitational/debian-venti:go1.24.5-bookworm
 
 ARG UID
 ARG GID

--- a/docker/suite/Dockerfile
+++ b/docker/suite/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM quay.io/gravitational/debian-grande:bullseye
+FROM quay.io/gravitational/debian-grande:bookworm
 
 RUN apt-get update && \
     apt-get install -y curl unzip gnupg2 dirmngr


### PR DESCRIPTION
### Why?
1. Upgrading gravity to ubuntu 24 requires the test framework to be compatible with Ubuntu 24

### What?
1. Upgraded docker debian images to debian 12
2. Upgraded os to ubuntu 24

### Test Plan:
Successful E2E pipeline at [jenkins](https://polaris-builds.stark.rubrik.com/job/trident/job/gravity/job/Gravity_e2e_pipeline/job/temp-trident-upgrade-u-24/28/)